### PR TITLE
fixing Image_Processing_Queue/Exception

### DIFF
--- a/src/Image_Processing_Queue/Exception.php
+++ b/src/Image_Processing_Queue/Exception.php
@@ -5,4 +5,4 @@ namespace Image_Processing_Queue;
 /**
 * Custom exception class for IPQ background processing
 */
-class Exception extends Exception {}
+class Exception extends \Exception {}


### PR DESCRIPTION
A class can not extend itself. The exception should extend the Exception from the root namespace.
Else it would fail and scheduled jobs get stuck.